### PR TITLE
Repro all models on GCP with lemmatization turned off

### DIFF
--- a/ConvertNER/convert_NER.py
+++ b/ConvertNER/convert_NER.py
@@ -208,6 +208,10 @@ for f in os.listdir(os.path.join(path_prefix, corpus_path)):
 
     doc_id += 1
     corpus += [doc_json]
-    
-with open(os.path.expanduser(os.path.join(path_prefix, output_path, output)), 'w+') as f:
+
+out_path = os.path.expanduser(os.path.join(path_prefix, output_path))
+if not os.path.exists(out_path):
+    os.makedirs(out_path)
+
+with open(os.path.join(out_path, output), 'w+') as f:
     json.dump(corpus, f)

--- a/NER.json.dvc
+++ b/NER.json.dvc
@@ -2,12 +2,13 @@ cmd: python ConvertNER/convert_NER.py
 deps:
 - md5: 8b70b91a64dc1374337cf326b9cbf168.dir
   path: data/NKJP-PodkorpusMilionowy-1.2
-- md5: c9529b45e2559433815b45a95784ca89
+- md5: 254e5a5e83b0a1c1acf0eb4b6f0a1f2f
   path: ConvertNER/convert_NER.py
-md5: 737197f9ee35cb70af7d117a9a583937
+md5: cb7781beee7bdaa797129499e15dd6ab
 outs:
 - cache: true
-  md5: eae7d3b22607b1cea2c9522471314816
+  md5: 98700b0e4cad95693de2a3886ed2e247
   metric: false
   path: data/NER/NER.json
+  persist: false
 wdir: .

--- a/blank_NKJP_word2vec.dvc
+++ b/blank_NKJP_word2vec.dvc
@@ -1,11 +1,11 @@
 cmd: python -m spacy init-model pl models/blank_NKJP_word2vec --vectors-loc data/vectors_300.txt
 deps:
-- md5: e662bda284b879d4bcbde41d6d2be3dd
+- md5: 23e089e8540c5de8185a7107ec742d6c
   path: data/vectors_300.txt
-md5: 335745dd1f3a2c025cb3422e8e24c9f7
+md5: 5f635b1782a087f355c91a2d9afc6e8b
 outs:
 - cache: true
-  md5: 588b80c0de02c590605cf7f8cba1d9d3.dir
+  md5: f094aa639c48653a70191cb6a4912e77.dir
   metric: false
   path: models/blank_NKJP_word2vec
   persist: false

--- a/data/NER/.gitignore
+++ b/data/NER/.gitignore
@@ -1,0 +1,1 @@
+/NER.json

--- a/data/NKJP-PodkorpusMilionowy-1.2.dvc
+++ b/data/NKJP-PodkorpusMilionowy-1.2.dvc
@@ -1,5 +1,8 @@
-md5: 5c7d380226d54dcf16d1826a34163560
+md5: 03d43b28ac163c7b15265fb3e8e0a79e
 outs:
 - cache: true
   md5: 8b70b91a64dc1374337cf326b9cbf168.dir
+  metric: false
   path: NKJP-PodkorpusMilionowy-1.2
+  persist: false
+wdir: .

--- a/data/training/NER/.gitignore
+++ b/data/training/NER/.gitignore
@@ -1,1 +1,4 @@
 *.json
+/ner-train.json
+/ner-test.json
+/ner-validation.json

--- a/ner-train.json.dvc
+++ b/ner-train.json.dvc
@@ -1,20 +1,25 @@
 cmd: python training/split-data.py --input-file data/NER/NER.json --train-output data/training/NER/ner-train.json
   --validation-output data/training/NER/ner-validation.json --test-output data/training/NER/ner-test.json
 deps:
-- md5: 26eda26aa4dfe010f02abd903236319f
+- md5: 98700b0e4cad95693de2a3886ed2e247
   path: data/NER/NER.json
-md5: b2b39f757474106d83d09a68acd530e4
+- md5: 006505262f56bcf5d91167663f46a37e
+  path: training/split-data.py
+md5: 8ac7c6b03baaab42c64fc74cc6f0421d
 outs:
 - cache: true
-  md5: 5f66f32e9687176fe6fe73b5dabe3ccc
+  md5: 4f5fa0d46b3bcf1aad179a2516a239e6
   metric: false
   path: data/training/NER/ner-train.json
+  persist: false
 - cache: true
-  md5: 8fb84b9a2c25d2b003027303456bafed
+  md5: 0e8ae51b3484d214627bc3b53d90aac3
   metric: false
   path: data/training/NER/ner-test.json
+  persist: false
 - cache: true
-  md5: f936ba60e47a04063ce21d898cff7bda
+  md5: 493ecce354af3119a3770322235fe626
   metric: false
   path: data/training/NER/ner-validation.json
+  persist: false
 wdir: .

--- a/ner_nkjp_word2vec.dvc
+++ b/ner_nkjp_word2vec.dvc
@@ -1,16 +1,18 @@
 cmd: python -m spacy train pl models/ner_nkjp_word2vec data/training/NER/ner-train.json
-  data/training/NER/ner-validation.json --vectors models/blank_NKJP_word2vec -p ner -n 9
+  data/training/NER/ner-validation.json --vectors models/blank_NKJP_word2vec -p ner
+  -g 0 -n 9
 deps:
-- md5: bb32d7633339ebfd28c27c7efab59d68.dir
+- md5: f094aa639c48653a70191cb6a4912e77.dir
   path: models/blank_NKJP_word2vec
-- md5: 5f66f32e9687176fe6fe73b5dabe3ccc
+- md5: 4f5fa0d46b3bcf1aad179a2516a239e6
   path: data/training/NER/ner-train.json
-- md5: f936ba60e47a04063ce21d898cff7bda
+- md5: 493ecce354af3119a3770322235fe626
   path: data/training/NER/ner-validation.json
-md5: 00663a599ca8af5e2e00cd2d3f79860b
+md5: 6ce87c55bc71676db930ef36e6f81c9b
 outs:
 - cache: true
-  md5: 7f07f67d7cc07932aa286e36a7ce65e9.dir
+  md5: ee74e26ca2c8c5a2317586d40b3cb28e.dir
   metric: false
   path: models/ner_nkjp_word2vec
+  persist: false
 wdir: .

--- a/pos_NKJP-100_word2vec.dvc
+++ b/pos_NKJP-100_word2vec.dvc
@@ -1,15 +1,18 @@
 cmd: python -m spacy train pl models/pos_NKJP-100_word2vec data/training/pos-100/pos-train.json
-  data/training/pos-100/pos-validation.json -n 12 -g 0 --vectors models/blank_NKJP_word2vec -p tagger
+  data/training/pos-100/pos-validation.json -n 12 -g 0 --vectors models/blank_NKJP_word2vec
+  -p tagger
 deps:
 - md5: ec1c40cf607177f143f26458ac2656a6
   path: data/training/pos-100/pos-train.json
 - md5: 5756df171c0277001cfb2c7ca99d89e7
   path: data/training/pos-100/pos-validation.json
-- md5: 330ef45fe5e432f8c3e025f455a61cd5.dir
+- md5: fa31acf018c61fd7af1d8e98e965e31d.dir
   path: models/blank_NKJP_word2vec
-md5: df2e5d645618a7eacd1a194b2ea180a4
+md5: c7d9060f460417e09838632bae3bc96b
 outs:
 - cache: true
-  md5: 566c224f3d98e9e6310a661386300e14.dir
+  md5: 7a90371629f9c3ec27339b20dcdb03a2.dir
   metric: false
   path: models/pos_NKJP-100_word2vec
+  persist: false
+wdir: .

--- a/pos_NKJP-100_word2vec.dvc
+++ b/pos_NKJP-100_word2vec.dvc
@@ -1,5 +1,5 @@
 cmd: python -m spacy train pl models/pos_NKJP-100_word2vec data/training/pos-100/pos-train.json
-  data/training/pos-100/pos-validation.json -n 9 --vectors models/blank_NKJP_word2vec -p tagger
+  data/training/pos-100/pos-validation.json -n 12 -g 0 --vectors models/blank_NKJP_word2vec -p tagger
 deps:
 - md5: ec1c40cf607177f143f26458ac2656a6
   path: data/training/pos-100/pos-train.json

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,6 @@ google.cloud.storage
 sklearn
 pandas
 conll-df
+cupy-cuda100
+thinc_gpu_ops
+thinc[cuda100]

--- a/training/split-data.py
+++ b/training/split-data.py
@@ -14,10 +14,10 @@ class Split(object):
 
 
 @click.command(help="Split JSON converted for POS tagger (input-file) training into train, test and validation files (based on given probabilities).")
-@click.option('--input-file', type=str)
-@click.option('--train-output', type=str)
-@click.option('--validation-output', type=str)
-@click.option('--test-output', type=str)
+@click.option('--input-file', type=str, required=True)
+@click.option('--train-output', type=str, required=True)
+@click.option('--validation-output', type=str, required=True)
+@click.option('--test-output', type=str, required=True)
 @click.option('--train-prob', default=0.5)
 @click.option('--validation-prob', default=0.25)
 @click.option('--test-prob', default=0.25)

--- a/trees-pos_LFG_word2vec.dvc
+++ b/trees-pos_LFG_word2vec.dvc
@@ -2,14 +2,14 @@ cmd: python -m spacy train pl models/trees-pos_LFG_word2vec data/dependency_tree
   data/dependency_trees/LFG_spacy_converted/pl_lfg-ud-dev.json --vectors models/blank_NKJP_word2vec/
   -g 0 -n 18 --gold-preproc -p tagger,parser
 deps:
-- md5: 588b80c0de02c590605cf7f8cba1d9d3.dir
+- md5: 811f1e5877aa6deae82acbc33fbf3696.dir
   path: models/blank_NKJP_word2vec
 - md5: c83bae27154249b29141ab05b7e3ff25.dir
   path: data/dependency_trees/LFG_spacy_converted
-md5: 1b02c8e5080937fd1e7b1d5b1b10c6d6
+md5: d3dced814e7cdf04db3ee9be45f00d9d
 outs:
 - cache: true
-  md5: 82c37584f14578e191cb2106e338a7b1.dir
+  md5: d320adafecd0bf5173e6f3cacc5f4da0.dir
   metric: false
   path: models/trees-pos_LFG_word2vec
   persist: false

--- a/trees-pos_LFG_word2vec.dvc
+++ b/trees-pos_LFG_word2vec.dvc
@@ -1,5 +1,6 @@
 cmd: python -m spacy train pl models/trees-pos_LFG_word2vec data/dependency_trees/LFG_spacy_converted/pl_lfg-ud-train.json
-  data/dependency_trees/LFG_spacy_converted/pl_lfg-ud-dev.json --vectors models/blank_NKJP_word2vec/ --gold-preproc -p tagger,parser
+  data/dependency_trees/LFG_spacy_converted/pl_lfg-ud-dev.json --vectors models/blank_NKJP_word2vec/
+  -g 0 -n 18 --gold-preproc -p tagger,parser
 deps:
 - md5: 588b80c0de02c590605cf7f8cba1d9d3.dir
   path: models/blank_NKJP_word2vec

--- a/vectors_300.txt.dvc
+++ b/vectors_300.txt.dvc
@@ -4,10 +4,10 @@ deps:
   path: data/NKJP_1.2_nltk
 - md5: 1dcf1e301974b9bdf3cbbc2d1a76cfa9
   path: vectors/train_vectors_300.py
-md5: f61512ea509d394254e6887612781545
+md5: a1db11c944dc8afc587d7a3d8d691f16
 outs:
 - cache: true
-  md5: e662bda284b879d4bcbde41d6d2be3dd
+  md5: 23e089e8540c5de8185a7107ec742d6c
   metric: false
   path: data/vectors_300.txt
   persist: false


### PR DESCRIPTION
Summary of changes:
- fixed multiple bugs (bad paths, spacy 2.1 upgrade)
- all artifacts pushed
- all previous training results matched
- does NOT work with current lemmatizer due to its extremely low speed

EDIT: Now that improved train is merged, we only need to disable lemmatization
To reproduce everything, you need the spacy version created by:
```
git fetch --all
git checkout pl-our-tagmap
```
followed by a patch to the lemmatizer that effectively disables it:
```
diff --git a/spacy/lang/pl/lemmatizer/lemmatizer.py b/spacy/lang/pl/lemmatizer/lemmatizer.py
index 7c07ba3a..a069c37b 100644
--- a/spacy/lang/pl/lemmatizer/lemmatizer.py
+++ b/spacy/lang/pl/lemmatizer/lemmatizer.py
@@ -16,6 +16,7 @@ class PolishLemmatizer(object):
         self.lookup_table = lookup if lookup is not None else {}

     def __call__(self, string, univ_pos, morphology=None):
+        return [string.lower()]
         if univ_pos in (NOUN, 'NOUN', 'noun'):
             univ_pos = 'noun'
         elif univ_pos in (VERB, 'VERB', 'verb'):
```
I'm not pushing this junk to our spacy fork on purpose.

@Gizzio I need your review on this since you need it for the demo backend asap, it shouldn't take long.
Also, make sure to check whether it closes #48 or not, I am marking it so that it does but we will need to do this once again after the new lemmatizer is complete.